### PR TITLE
Add a `CMakeLists.txt` for use in CMake projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+
+[CMakeLists.txt]
+end_of_line = lf

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ open-simplex-noise-test
 open-simplex-noise.o
 *.png
 
+/.cache*
+/build*
+/__cmake*
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+
+project(open-simplex-noise-in-c)
+
+option(OSN_BUILD_TEST "Build the test binary?" OFF)
+set(OSN_FLOAT_TYPE double CACHE STRING
+  "Floating-point type to use for caclulating noise functions.")
+
+add_library(open-simplex-noise-in-c
+  ${CMAKE_CURRENT_SOURCE_DIR}/open-simplex-noise.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/open-simplex-noise.h)
+target_include_directories(open-simplex-noise-in-c
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(open-simplex-noise-in-c
+  PUBLIC OSNFLOAT=${OSN_FLOAT_TYPE})
+
+if (OSN_BUILD_TEST)
+  find_package(ZLIB REQUIRED) # PNG dependency
+  find_package(PNG REQUIRED)
+  
+  add_executable(open-simplex-noise-in-c-test
+    ${CMAKE_CURRENT_SOURCE_DIR}/open-simplex-noise-test.c)
+  target_link_libraries(open-simplex-noise-in-c-test
+    PRIVATE PNG::PNG open-simplex-noise-in-c)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(open-simplex-noise-in-c)
 
 option(OSN_BUILD_TEST "Build the test binary?" OFF)
 set(OSN_FLOAT_TYPE double CACHE STRING
-  "Floating-point type to use for caclulating noise functions.")
+  "Floating-point type to use for calculating noise functions.")
 
 add_library(open-simplex-noise-in-c
   ${CMAKE_CURRENT_SOURCE_DIR}/open-simplex-noise.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,16 @@ cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(open-simplex-noise-in-c)
 
 option(OSN_BUILD_TEST "Build the test binary?" OFF)
-set(OSN_FLOAT_TYPE double CACHE STRING
-  "Floating-point type to use for calculating noise functions.")
 
 add_library(open-simplex-noise-in-c
   ${CMAKE_CURRENT_SOURCE_DIR}/open-simplex-noise.c
   ${CMAKE_CURRENT_SOURCE_DIR}/open-simplex-noise.h)
 target_include_directories(open-simplex-noise-in-c
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_definitions(open-simplex-noise-in-c
-  PUBLIC OSNFLOAT=${OSN_FLOAT_TYPE})
+if (OSN_FLOAT_TYPE)
+  target_compile_definitions(open-simplex-noise-in-c
+    PUBLIC OSNFLOAT=${OSN_FLOAT_TYPE})
+endif()
 
 if (OSN_BUILD_TEST)
   find_package(ZLIB REQUIRED) # PNG dependency


### PR DESCRIPTION
Loving this library! I'm using it in several of my CMake-based projects, but every time I do, I have to write my own library-target, which gets annoying to copy-paste around:

```cmake
add_library(noise
    ${noise_SOURCE_DIR}/open-simplex-noise.c
    ${noise_SOURCE_DIR}/open-simplex-noise.h)
target_include_directories(noise PUBLIC ${noise_SOURCE_DIR})
target_compile_definitions(noise PUBLIC OSNFLOAT=float)
```

I've tested this `CMakeLists.txt` on Windows 10 (with GCC-mingw64) and under Ubuntu WSL (also GCC) - the library portion works great. The test binary also compiles and runs under WSL, but I haven't tested it on Windows because `find_package` is a bit tricky to get working there; usually, I build all the libraries from sources using CMake's `FetchContent` to checkout the repos.

`OSN_FLOAT_TYPE` is also included as an option to override `OSNFLOAT` globally; though, I am unsure whether I defined it correctly since this is how I had to override to `float` inside a project:

```cmake
set(OSN_FLOAT_TYPE float CACHE STRING "" FORCE)
```

Had to add a bunch of `.gitignore` entries due to IDE configuration concerns: at least under my configuration, both VSCode and Emacs produce those files and directories for all CMake projects I open and configure. The `.editorconfig` is there for text-encoding consistency; feel free to nuke it.